### PR TITLE
Use client

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The gateway currently supports 2 operations:
 In order to add an item to a collection, a POST request must be sent to resource `/api/collection/{collectionLocId}`. See below for an example of request.
 
 ```
-curl -v http://localhost:8080/api/collection/$COLLECTION_LOC_ID -d '{"webSocketUrl":"wss://test-rpc01.logion.network","suri":"$SECRET_SEED","itemId":"$ITEM_ID","itemDescription":"$ITEM_DESCRIPTION"}' -H "Content-Type: application/json"
+curl -v http://localhost:8080/api/collection/$COLLECTION_LOC_ID -d '{"webSocketUrl":"wss://test-rpc01.logion.network","directoryUrl":"https://test-directory.logion.network","suri":"$SECRET_SEED","itemId":"$ITEM_ID","itemDescription":"$ITEM_DESCRIPTION"}' -H "Content-Type: application/json"
 ```
 
 If the response has status code `200`, then the item has been successfully submitted (i.e. the transaction was put in a block).
@@ -55,8 +55,6 @@ A response status code `400` may be returned in case of failure. The response bo
 
 ```
 {
-  "pallet": "...",
-  "error": "...",
   "details": "..."
 }
 ```
@@ -66,7 +64,7 @@ A response status code `400` may be returned in case of failure. The response bo
 A PUT request must be sent to resource `/api/collection/{collectionLocId}/{itemId}`. See below for an example of request.
 
 ```
-curl -v -X PUT http://localhost:8080/api/collection/$COLLECTION_LOC_ID/$ITEM_ID -d '{"webSocketUrl":"wss://test-rpc01.logion.network"}' -H "Content-Type: application/json"
+curl -v -X PUT http://localhost:8080/api/collection/$COLLECTION_LOC_ID/$ITEM_ID -d '{"webSocketUrl":"wss://test-rpc01.logion.network","directoryUrl":"https://test-directory.logion.network"}' -H "Content-Type: application/json"
 ```
 
 If the response has status code `200`, then the item exists in the given collection and the response body looks like this:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - CHAIN_SPEC=dev
       - NODE_KEY=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
-      - CUSTOM_OPTIONS=--alice --ws-external --rpc-cors all
+      - CUSTOM_OPTIONS=--alice --rpc-external --rpc-cors all
   gateway:
     image: logionnetwork/logion-gateway:latest
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,55 @@
 version: "3.6"
 services:
+  private-database:
+    image: logionnetwork/logion-postgres:${PG_TAG:-latest}
+    environment:
+      - POSTGRES_PASSWORD=secret
   node:
     image: logionnetwork/logion-node:latest
     ports:
-      - 9944:9944
+      - 127.0.0.1:9944:9944
     environment:
       - CHAIN_SPEC=dev
       - NODE_KEY=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
       - CUSTOM_OPTIONS=--alice --rpc-external --rpc-cors all
+  backend:
+    image: logionnetwork/logion-backend:${BACKEND_TAG:-latest}
+    ports:
+      - 127.0.0.1:8070:8080
+    environment:
+      - JWT_SECRET=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
+      - JWT_ISSUER=12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2
+      - TYPEORM_HOST=private-database
+      - WS_PROVIDER_URL=ws://node:9944
+      - OWNER=5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+      - DIRECTORY_URL=http://directory:8080
+      - SMTP_ENABLED=false
+      - IPFS_CLUSTER_HOST=/dns4/ipfs-cluster1/tcp/9094
+      - IPFS_HOST=/dns4/ipfs1/tcp/5001
+      - IPFS_MIN_REPLICA=1
+      - IPFS_MAX_REPLICA=2
+      - ENC_PASSWORD=secret
+      - FEATURE_VOTE=true
+    depends_on:
+      - node
+      - private-database
+  directory-database:
+    image: postgres:12
+    environment:
+      - POSTGRES_PASSWORD=secret
+  directory:
+    image: logionnetwork/logion-directory:${DIRECTORY_TAG:-latest}
+    ports:
+      - 127.0.0.1:8090:8080
+    environment:
+      - JWT_SECRET=c12b6d18942f5ee8528c8e2baf4e147b5c5c18710926ea492d09cbd9f6c9f82a
+      - JWT_ISSUER=12D3KooWBmAwcd4PJNJvfV89HwE48nwkRmAgo8Vy3uQEyNNHBox2
+      - WS_PROVIDER_URL=ws://node:9944
+      - TYPEORM_HOST=directory-database
+    depends_on:
+      - node
+      - directory-database
   gateway:
     image: logionnetwork/logion-gateway:latest
     ports:
-      - 8080:8080
+      - 127.0.0.1:8080:8080

--- a/integration/Main.spec.ts
+++ b/integration/Main.spec.ts
@@ -1,10 +1,11 @@
 import { Keyring } from "@polkadot/api";
 import { KeyringPair } from "@polkadot/keyring/types";
+import { waitReady } from "@polkadot/wasm-crypto";
+import { Adapters, UUID, Currency, buildApiClass } from "@logion/node-api";
+import axios from "axios";
+import { AcceptedRequest, KeyringSigner, LogionClient, OpenLoc, PendingRequest, Signer } from "@logion/client";
 import { IKeyringPair, ISubmittableResult } from "@polkadot/types/types";
 import { SubmittableExtrinsic } from "@polkadot/api/promise/types";
-import { waitReady } from "@polkadot/wasm-crypto";
-import { buildApiClass, LogionNodeApiClass, UUID, Currency, Adapters } from "@logion/node-api";
-import axios from "axios";
 
 describe("Gateway", () => {
 
@@ -14,15 +15,19 @@ describe("Gateway", () => {
         const itemId = "0x5fa4160170ad053c261d3e441e4b10105463f44690c3749ab78846cb1bfe7659";
         const itemDescription = "Some description.";
         try {
+            console.log("Adding item with gateway");
             await axios.post(`http://localhost:8080/api/collection/${collectionLocId.toDecimalString()}`, {
                 webSocketUrl: "ws://node:9944",
+                directoryUrl: "http://directory:8080",
                 suri: REQUESTER_SECRET_SEED,
                 itemId,
                 itemDescription,
             });
 
+            console.log("Getting item with gateway");
             const response = await axios.put(`http://localhost:8080/api/collection/${collectionLocId.toDecimalString()}/${itemId}`, {
                 webSocketUrl: "ws://node:9944",
+                directoryUrl: "http://directory:8080",
             });
             expect(response.data.collectionLocId).toBe(collectionLocId.toDecimalString());
             expect(response.data.itemId).toBe(itemId);
@@ -30,6 +35,8 @@ describe("Gateway", () => {
         } catch(e: any) {
             if("response" in e && "data" in e.response && "details" in e.response.data) {
                 throw new Error(e.response.data.details);
+            } else if("response" in e && "data" in e.response && "errorMessage" in e.response.data) {
+                throw new Error(e.response.data.errorMessage);
             } else {
                 throw e;
             }
@@ -42,7 +49,6 @@ describe("Gateway", () => {
 let keyring: Keyring;
 let alice: KeyringPair;
 let requester: KeyringPair;
-let api: LogionNodeApiClass;
 let collectionLocId: UUID;
 
 async function setup(): Promise<void> {
@@ -50,26 +56,21 @@ async function setup(): Promise<void> {
     keyring = new Keyring({ type: 'sr25519' });
     alice = keyring.addFromUri(ALICE_SEED);
     requester = keyring.addFromUri(REQUESTER_SECRET_SEED);
-    api = await buildApiClass("ws://127.0.0.1:9944");
 
-    const amount = Currency.toCanonicalAmount(Currency.nLgnt(5000n));
-    const sendMoneyToRequester = api.polkadot.tx.balances.transfer(REQUESTER, amount);
-    await signAndSend(alice, sendMoneyToRequester);
+    let client = await LogionClient.create({
+        rpcEndpoints: [ "ws://127.0.0.1:9944" ],
+        directoryEndpoint: "http://localhost:8090"
+    });
+    const signer = new KeyringSigner(keyring, GATEWAY_SIGN_SEND_STRAGEGY);
+    client = await client.authenticate([
+        client.logionApi.queries.getValidAccountId(ALICE, "Polkadot"),
+        client.logionApi.queries.getValidAccountId(REQUESTER, "Polkadot"),
+    ], signer);
 
-    collectionLocId = new UUID();
-    const createCollectionLoc = api.polkadot.tx.logionLoc.createCollectionLoc(
-        Adapters.toLocId(collectionLocId),
-        ALICE,
-        null,
-        200,
-        false,
-    );
-    await signAndSend(requester, createCollectionLoc);
+    await createIdentityLoc({ client, signer });
+    collectionLocId = await createCollectionLoc({ client, signer });
 
-    const closeCollectionLoc = api.polkadot.tx.logionLoc.close(
-        Adapters.toLocId(collectionLocId),
-    );
-    await signAndSend(alice, closeCollectionLoc);
+    await updateAliceBackend();
 }
 
 const ALICE_SEED = "0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a";
@@ -80,6 +81,99 @@ const REQUESTER_SECRET_SEED = "unique chase zone team upset caution match west e
 
 export const REQUESTER = "5DPLBrBxniGbGdFe1Lmdpkt6K3aNjhoNPJrSJ51rwcmhH2Tn";
 
+const GATEWAY_SIGN_SEND_STRAGEGY = {
+    canUnsub(result: ISubmittableResult): boolean {
+        return result.isInBlock;
+    }
+};
+
+async function createIdentityLoc(params: { client: LogionClient, signer: Signer }): Promise<UUID> {
+    const { client, signer } = params;
+
+    console.log("Setting requester balance");
+    const aliceClient = client.withCurrentAddress(client.logionApi.queries.getValidAccountId(ALICE, "Polkadot"));
+    let aliceBalances = await aliceClient.balanceState();
+
+    const amount = Currency.nLgnt(5000n);
+    aliceBalances = await aliceBalances.transfer({ amount, destination: REQUESTER, signer });
+
+    const requesterClient = client.withCurrentAddress(client.logionApi.queries.getValidAccountId(REQUESTER, "Polkadot"));
+    let requesterLocs = await requesterClient.locsState();
+    const userIdentity = {
+        firstName: "John",
+        lastName: "Doe",
+        email: "john@doe.com",
+        phoneNumber: "+1234",
+    };
+    const userPostalAddress = {
+        line1: "Main Street 4",
+        line2: "",
+        postalCode: "1000",
+        city: "Brussels",
+        country: "Belgium",
+    };
+    console.log("Creating identity LOC");
+    const pendingRequesterIdentityLoc = await requesterLocs.requestIdentityLoc({
+        description: "My identity LOC",
+        draft: false,
+        legalOfficer: requesterClient.getLegalOfficer(ALICE),
+        userIdentity,
+        userPostalAddress,
+    });
+    const identityLocId = pendingRequesterIdentityLoc.data().id;
+    let aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: ALICE, locTypes: ["Identity"], statuses: ["REVIEW_PENDING"] } });
+    const pendingAliceIdentityLoc = aliceLocs.findById(identityLocId) as PendingRequest;
+    await pendingAliceIdentityLoc.legalOfficer.accept({ signer });
+    const acceptedRequesterIdentityLoc = await pendingRequesterIdentityLoc.refresh() as AcceptedRequest;
+    await acceptedRequesterIdentityLoc.open({ signer });
+    aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: ALICE, locTypes: ["Identity"], statuses: ["OPEN"] } });
+    const openAliceIdentityLoc = aliceLocs.findById(identityLocId) as OpenLoc;
+    await openAliceIdentityLoc.legalOfficer.close({ signer });
+
+    return identityLocId;
+}
+
+async function createCollectionLoc(params: { client: LogionClient, signer: Signer }): Promise<UUID> {
+    const { client, signer } = params;
+
+    const aliceClient = client.withCurrentAddress(client.logionApi.queries.getValidAccountId(ALICE, "Polkadot"));
+    const requesterClient = client.withCurrentAddress(client.logionApi.queries.getValidAccountId(REQUESTER, "Polkadot"));
+
+    console.log("Creating collection LOC");
+    let requesterLocs = await requesterClient.locsState();
+    const pendingRequesterLoc = await requesterLocs.requestCollectionLoc({
+        description: "My collection LOC",
+        draft: false,
+        legalOfficer: requesterClient.getLegalOfficer(ALICE),
+    });
+    const collectionLocId = pendingRequesterLoc.data().id;
+    let aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: ALICE, locTypes: ["Collection"], statuses: ["REVIEW_PENDING"] } });
+    const pendingAliceLoc = aliceLocs.findById(collectionLocId) as PendingRequest;
+    await pendingAliceLoc.legalOfficer.accept({ signer });
+    const acceptedRequesterLoc = await pendingRequesterLoc.refresh() as AcceptedRequest;
+    await acceptedRequesterLoc.openCollection({ collectionCanUpload: false, collectionMaxSize: 1, signer });
+    aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: ALICE, locTypes: ["Collection"], statuses: ["OPEN"] } });
+    const openAliceIdentityLoc = aliceLocs.findById(collectionLocId) as OpenLoc;
+    await openAliceIdentityLoc.legalOfficer.close({ signer });
+
+    return collectionLocId;
+}
+
+async function updateAliceBackend() {
+    console.log("Resetting Alice backend URL on chain");
+    const api = await buildApiClass("ws://127.0.0.1:9944");
+    await signAndSend(alice, api.polkadot.tx.loAuthorityList
+        .updateLegalOfficer(alice.address, {
+            Host: {
+                nodeId: "0x0024080112201ce5f00ef6e89374afb625f1ae4c1546d31234e87e3c3f51a62b91dd6bfa57df",
+                baseUrl: "http://backend:8080", // Resolveable by gateway
+                region: "Europe",
+            }
+        })
+    );
+    await api.polkadot.disconnect();
+}
+
 function signAndSend(keypair: IKeyringPair, extrinsic: SubmittableExtrinsic): Promise<ISubmittableResult> {
     let unsub: () => void;
     return new Promise((resolve, error) => {
@@ -87,7 +181,7 @@ function signAndSend(keypair: IKeyringPair, extrinsic: SubmittableExtrinsic): Pr
             if(result.isError) {
                 unsub();
                 error(new Error("pre-dispatch error"));
-            } else if (result.status.isInBlock) {
+            } else if (GATEWAY_SIGN_SEND_STRAGEGY.canUnsub(result)) {
                 unsub();
                 if(result.dispatchError) {
                     error(new Error(Adapters.getErrorMessage(result.dispatchError)));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "logion-gateway",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "private": true,
     "author": {
         "name": "Logion Team",
@@ -18,7 +18,7 @@
         "coverage": "nyc yarn run test"
     },
     "dependencies": {
-        "@logion/node-api": "^0.17.0",
+        "@logion/node-api": "^0.17.1",
         "ansi-regex": "^6.0.1",
         "body-parser": "^1.19.1",
         "bson": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
         "start": "yarn run build && NODE_ENV=development node dist/app.js",
         "serve": "tsc-watch --p ./tsconfig.app.json --onSuccess \"env NODE_ENV=development node dist/app.js\"",
         "test": "NODE_OPTIONS=--loader=ts-node/esm jasmine --config=jasmine.json",
-        "integration-test": "docker-compose up -d && NODE_OPTIONS=--loader=ts-node/esm jasmine --config=jasmine-integration.json ; docker-compose down",
+        "integration-test": "docker-compose up -d && sleep 3 && ./scripts/init_data.sh && NODE_OPTIONS=--loader=ts-node/esm jasmine --config=jasmine-integration.json ; docker-compose down",
         "coverage": "nyc yarn run test"
     },
     "dependencies": {
-        "@logion/node-api": "^0.17.1",
+        "@logion/client": "^0.28.3-6",
         "ansi-regex": "^6.0.1",
         "body-parser": "^1.19.1",
         "bson": "^4.6.1",
@@ -54,7 +54,7 @@
         "axios": "^1.3.1",
         "jasmine": "^4.0.2",
         "jasmine-spec-reporter": "^7.0.0",
-        "moq.ts": "^7.3.4",
+        "moq.ts": "^10.0.6",
         "nyc": "^15.1.0",
         "rimraf": "^3.0.2",
         "supertest": "^6.2.1",

--- a/resources/schemas.json
+++ b/resources/schemas.json
@@ -13,6 +13,9 @@
                     "webSocketUrl": {
                         "$ref": "#/components/schemas/WebSocketUrl"
                     },
+                    "directoryUrl": {
+                        "$ref": "#/components/schemas/DirectoryUrl"
+                    },
                     "suri": {
                         "type": "string",
                         "example": "used route main sock exotic mule screen whale dance tail ladder lift",
@@ -31,6 +34,9 @@
                 "properties": {
                     "webSocketUrl": {
                         "$ref": "#/components/schemas/WebSocketUrl"
+                    },
+                    "directoryUrl": {
+                        "$ref": "#/components/schemas/DirectoryUrl"
                     }
                 }
             },
@@ -38,6 +44,11 @@
                 "type": "string",
                 "example": "wss://test-rpc01.logion.network",
                 "description": "The WebSocket endpoint of a logion chain"
+            },
+            "DirectoryUrl": {
+                "type": "string",
+                "example": "https://test-directory.logion.network",
+                "description": "The LLO directory"
             },
             "ItemId": {
                 "type": "string",

--- a/scripts/directory_data.sql
+++ b/scripts/directory_data.sql
@@ -1,0 +1,4 @@
+TRUNCATE TABLE public.legal_officer;
+
+INSERT INTO public.legal_officer (address, first_name, last_name, email, phone_number, company, line1, line2, postal_code, city, country, additional_details)
+VALUES ('5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY', 'Alice', '', 'alice@logion.network', '+1234', 'Alice''s Company', 'Line 1', 'Line 2', '1000', 'City', 'Country', null);

--- a/scripts/init_data.sh
+++ b/scripts/init_data.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Directory
+docker-compose exec -T directory-database psql -U postgres postgres < scripts/directory_data.sql
+
+# Authority list
+node ./scripts/init_onchain_data.js

--- a/scripts/init_onchain_data.js
+++ b/scripts/init_onchain_data.js
@@ -1,0 +1,30 @@
+import { buildApiClass } from "@logion/node-api";
+import { Keyring } from '@polkadot/api';
+
+let api;
+let keyring;
+let alice;
+
+buildApiClass("ws://localhost:9944")
+.then(api0 => {
+    api = api0.polkadot;
+    keyring = new Keyring({ type: 'sr25519' });
+    alice = keyring.addFromUri("0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a");
+
+    return api.tx.loAuthorityList
+        .updateLegalOfficer(alice.address, {
+            Host: {
+                nodeId: "0x0024080112201ce5f00ef6e89374afb625f1ae4c1546d31234e87e3c3f51a62b91dd6bfa57df",
+                baseUrl: "http://localhost:8070",
+                region: "Europe",
+            }
+        })
+        .signAndSend(alice);
+})
+.then(hash => {
+    console.log(`Alice update tx hash: ${hash}`);
+    return api.disconnect();
+})
+.then(() => {
+    console.log("Done");
+});

--- a/src/controllers/components.ts
+++ b/src/controllers/components.ts
@@ -9,6 +9,7 @@ export interface components {
   schemas: {
     CreateCollectionItemView: {
       webSocketUrl?: components["schemas"]["WebSocketUrl"];
+      directoryUrl?: components["schemas"]["DirectoryUrl"];
       /**
        * @description The secret seed of collection's requester. May be provided in the mnemonic or hexadecimal form.
        * @example used route main sock exotic mule screen whale dance tail ladder lift
@@ -19,12 +20,18 @@ export interface components {
     };
     GetCollectionItemView: {
       webSocketUrl?: components["schemas"]["WebSocketUrl"];
+      directoryUrl?: components["schemas"]["DirectoryUrl"];
     };
     /**
      * @description The WebSocket endpoint of a logion chain
      * @example wss://test-rpc01.logion.network
      */
     WebSocketUrl: string;
+    /**
+     * @description The LLO directory
+     * @example https://test-directory.logion.network
+     */
+    DirectoryUrl: string;
     /**
      * @description The unique identifier of the item in the collection e.g. the hex representation of a file's SHA256 hash.
      * @example 0xc3e49c87aa19ec987501fc2e207f5928bd31ee948f69455c733416564da158c5

--- a/src/services/logion.service.ts
+++ b/src/services/logion.service.ts
@@ -1,17 +1,21 @@
 import { injectable } from "inversify";
 import { Keyring } from '@polkadot/api';
-import type { IKeyringPair } from '@polkadot/types/types';
-import { buildApiClass, LogionNodeApiClass } from '@logion/node-api';
+import { LogionClient, LogionClientConfig } from '@logion/client';
+import FormData from "form-data";
 
 @injectable()
 export class LogionService {
 
-    async buildApi(url: string): Promise<LogionNodeApiClass> {
-        return await buildApiClass(url);
+    async buildApi(config: LogionClientConfig): Promise<LogionClient> {
+        return await LogionClient.create({
+            ...config,
+            formDataLikeFactory: () => new FormData(),
+        });
     }
 
-    buildKeyringPair(suri: string): IKeyringPair {
+    buildKeyring(suri: string): Keyring {
         const keyring = new Keyring({ type: 'sr25519' });
-        return keyring.addFromUri(suri);
+        keyring.addFromUri(suri);
+        return keyring;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,9 +384,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.17.1":
-  version: 0.17.1
-  resolution: "@logion/node-api@npm:0.17.1"
+"@logion/client@npm:^0.28.3-6":
+  version: 0.28.3-6
+  resolution: "@logion/client@npm:0.28.3-6"
+  dependencies:
+    "@logion/node-api": ^0.18.0-3
+    axios: ^0.27.2
+    luxon: ^3.0.1
+    mime-db: ^1.52.0
+  checksum: 61313969149758227f8828e63b144debb2cc7eefb50161ce83b9a951b8c91d5c7d2b2bad68949eaea6b4f48ba7463803c688c63efc9d3d2fbdbda73b9fbe6a79
+  languageName: node
+  linkType: hard
+
+"@logion/node-api@npm:^0.18.0-3":
+  version: 0.18.0-3
+  resolution: "@logion/node-api@npm:0.18.0-3"
   dependencies:
     "@polkadot/api": ^10.9.1
     "@polkadot/util": ^12.3.2
@@ -394,7 +406,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 4de59ab6f52b25d096f57e43c26ce20c0bd5d4e47c383031b901f6d419cf57f01b01c18aceebcb1a645829e06ec8ce4158a0d6981fe498e0b3b6a44b967a0b5a
+  checksum: 787f85d139e58db9cab5853564374d80d52874dc6027891693402106a481157fded3162d60360c89b8f9e4d05241a9ef24bd607e5d3b85b581cc72b0a94f9e77
   languageName: node
   linkType: hard
 
@@ -1237,6 +1249,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^0.27.2":
+  version: 0.27.2
+  resolution: "axios@npm:0.27.2"
+  dependencies:
+    follow-redirects: ^1.14.9
+    form-data: ^4.0.0
+  checksum: 38cb7540465fe8c4102850c4368053c21683af85c5fdf0ea619f9628abbcb59415d1e22ebc8a6390d2bbc9b58a9806c874f139767389c862ec9b772235f06854
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.3.1":
   version: 1.3.1
   resolution: "axios@npm:1.3.1"
@@ -1981,7 +2003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.0":
+"follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.0":
   version: 1.15.2
   resolution: "follow-redirects@npm:1.15.2"
   peerDependenciesMeta:
@@ -2564,7 +2586,7 @@ __metadata:
   resolution: "logion-gateway@workspace:."
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.17.1
+    "@logion/client": ^0.28.3-6
     "@tsconfig/node18": ^1.0.1
     "@types/cors": ^2.8.12
     "@types/express": ^4.17.13
@@ -2592,7 +2614,7 @@ __metadata:
     moment: ^2.29.1
     mongoose: ^6.1.6
     mongoose-to-swagger: ^1.4.0
-    moq.ts: ^7.3.4
+    moq.ts: ^10.0.6
     node-fetch: 3.1.1
     nyc: ^15.1.0
     openapi-typescript: 5.1.0
@@ -2613,6 +2635,13 @@ __metadata:
   dependencies:
     yallist: ^4.0.0
   checksum: f97f499f898f23e4585742138a22f22526254fdba6d75d41a1c2526b3b6cc5747ef59c5612ba7375f42aca4f8461950e925ba08c991ead0651b4918b7c978297
+  languageName: node
+  linkType: hard
+
+"luxon@npm:^3.0.1":
+  version: 3.3.0
+  resolution: "luxon@npm:3.3.0"
+  checksum: 50cf17a0dc155c3dcacbeae8c0b7e80db425e0ba97b9cbdf12a7fc142d841ff1ab1560919f033af46240ed44e2f70c49f76e3422524c7fc8bb8d81ca47c66187
   languageName: node
   linkType: hard
 
@@ -2667,7 +2696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0":
+"mime-db@npm:1.52.0, mime-db@npm:^1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
   checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
@@ -2790,12 +2819,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"moq.ts@npm:^7.3.4":
-  version: 7.4.1
-  resolution: "moq.ts@npm:7.4.1"
+"moq.ts@npm:^10.0.6":
+  version: 10.0.8
+  resolution: "moq.ts@npm:10.0.8"
   dependencies:
-    tslib: 2.1.0
-  checksum: 8c3c52ef8dea9f4c1075d689ad9918395062c75e03b612f85a83023e094869427bb3e3c12b8a61fed7b5098a95473d7c0cbb1af5d0116ac38494eb5fc3f5fb03
+    tslib: "*"
+  checksum: 47a264649de0bf5cb4a483d10406502c979685ad44e35d44905e98dcc8101dd5e86765cc1cbc64548837566c2a6a9035f78162de4733e0b23ac7532b664c9fb5
   languageName: node
   linkType: hard
 
@@ -3989,10 +4018,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.1.0":
-  version: 2.1.0
-  resolution: "tslib@npm:2.1.0"
-  checksum: aa189c8179de0427b0906da30926fd53c59d96ec239dff87d6e6bc831f608df0cbd6f77c61dabc074408bd0aa0b9ae4ec35cb2c15f729e32f37274db5730cb78
+"tslib@npm:*":
+  version: 2.6.1
+  resolution: "tslib@npm:2.6.1"
+  checksum: b0d176d176487905b66ae4d5856647df50e37beea7571c53b8d10ba9222c074b81f1410fb91da13debaf2cbc970663609068bdebafa844ea9d69b146527c38fe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,9 +384,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.17.0":
-  version: 0.17.0
-  resolution: "@logion/node-api@npm:0.17.0"
+"@logion/node-api@npm:^0.17.1":
+  version: 0.17.1
+  resolution: "@logion/node-api@npm:0.17.1"
   dependencies:
     "@polkadot/api": ^10.9.1
     "@polkadot/util": ^12.3.2
@@ -394,7 +394,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 6998f1640b3c3045c1b27d2323fa1e6765c1a008addb760a94082456d77af97584978f408ccd557c5fafce0ad96a1f5d3166f71aee0812f85173adaa34ef51de
+  checksum: 4de59ab6f52b25d096f57e43c26ce20c0bd5d4e47c383031b901f6d419cf57f01b01c18aceebcb1a645829e06ec8ce4158a0d6981fe498e0b3b6a44b967a0b5a
   languageName: node
   linkType: hard
 
@@ -2564,7 +2564,7 @@ __metadata:
   resolution: "logion-gateway@workspace:."
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/node-api": ^0.17.0
+    "@logion/node-api": ^0.17.1
     "@tsconfig/node18": ^1.0.1
     "@types/cors": ^2.8.12
     "@types/express": ^4.17.13


### PR DESCRIPTION
* Companion of https://github.com/logion-network/logion-api/pull/174
* In order to properly create and read collection items, the use of `client` instead of `node-api` is required

logion-network/logion-internal#949