### PR TITLE
Handle parachain prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "coverage": "nyc yarn run test"
     },
     "dependencies": {
-        "@logion/client": "^0.42.0",
+        "@logion/client": "^0.42.1-2",
         "@logion/client-node": "^0.3.4",
         "ansi-regex": "^6.0.1",
         "body-parser": "^1.19.1",

--- a/src/controllers/collection.controller.ts
+++ b/src/controllers/collection.controller.ts
@@ -1,7 +1,7 @@
 import { injectable } from "inversify";
 import { Controller, ApiController, Async, HttpPost, NotFoundException, HttpPut, BadRequestException, HttpResponseException } from "dinoloop";
 import { OpenAPIV3 } from "express-oas-generator";
-import { UUID, Hash } from "@logion/node-api";
+import { UUID, Hash, ValidAccountId } from "@logion/node-api";
 
 import { components } from "./components.js";
 import { addTag, setControllerTag, setPathParameters, getDefaultResponsesNoContent, getRequestBody, getBodyContent } from "./doc.js";
@@ -80,7 +80,7 @@ export class CollectionController extends ApiController {
             directoryEndpoint,
         });
         const signer = new KeyringSigner(keyring, GATEWAY_SIGN_SEND_STRAGEGY);
-        const requester = api.logionApi.queries.getValidAccountId(keyring.getPairs()[0].address, "Polkadot");
+        const requester = ValidAccountId.polkadot(keyring.getPairs()[0].address);
         api = await api.authenticate([ requester ], signer);
         api = api.withCurrentAddress(requester);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,21 +395,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@logion/client@npm:^0.42.0":
-  version: 0.42.0
-  resolution: "@logion/client@npm:0.42.0"
+"@logion/client@npm:^0.42.1-2":
+  version: 0.42.1-2
+  resolution: "@logion/client@npm:0.42.1-2"
   dependencies:
-    "@logion/node-api": ^0.28.4
+    "@logion/node-api": ^0.29.0-2
     axios: ^1.6.7
     luxon: ^3.4.4
     mime-db: ^1.52.0
-  checksum: 5166de5f8acef6fe54f3ad27629c718f9384a5ab269f00726def4475436e54b845d7a1ddcf8f5ebb96b4cbbd7cf8ce766ef46f06c35ea09aaecb67a9c6def96b
+  checksum: f20b357002073d8e7c87f87a364eb39b995ea63cd0515f43e440ea6c6a42a20dd7ce5f834796ab7f36a9bb0772707f951a912b65d6e9c2370fbe893684bb9d6c
   languageName: node
   linkType: hard
 
-"@logion/node-api@npm:^0.28.4":
-  version: 0.28.4
-  resolution: "@logion/node-api@npm:0.28.4"
+"@logion/node-api@npm:^0.29.0-2":
+  version: 0.29.0-3
+  resolution: "@logion/node-api@npm:0.29.0-3"
   dependencies:
     "@polkadot/api": ^10.12.2
     "@polkadot/util": ^12.6.2
@@ -417,7 +417,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     fast-sha256: ^1.3.0
     uuid: ^9.0.0
-  checksum: 0a2ac1fe3cfb06326a4ca1374b786fafa634830471258d618aafefe0effb2e682a9febe4a301b71e5a9d22c5daaba2beb43f3838ca13ecfea8917da40bb14c3a
+  checksum: 8b7759ec19d4ebbf7eddf1c8a9d6308f2ee83c9fd9232538d04eaa2b35344eaf36554304ac8a95cf40baa5475eb75d990070b49b72bb84f21c3e0c73cc21f016
   languageName: node
   linkType: hard
 
@@ -2683,7 +2683,7 @@ __metadata:
   resolution: "logion-gateway@workspace:."
   dependencies:
     "@istanbuljs/nyc-config-typescript": ^1.0.2
-    "@logion/client": ^0.42.0
+    "@logion/client": ^0.42.1-2
     "@logion/client-node": ^0.3.4
     "@tsconfig/node18": ^1.0.1
     "@types/cors": ^2.8.12


### PR DESCRIPTION
* Upgrades Logion deps.
* Uses `ValidAccountId.polkadot(...)`.

logion-network/logion-internal#1216